### PR TITLE
Fix for handle-singular-aff-no-links

### DIFF
--- a/src/handle-singular-aff-no-links.xsl
+++ b/src/handle-singular-aff-no-links.xsl
@@ -26,7 +26,7 @@
         <aff id="aff1">
             <xsl:apply-templates select="@*[name()!='id']"/>
             <label>1</label>
-            <xsl:apply-templates select="*[name()!='label']"/>
+            <xsl:apply-templates select="node()[name()!='label']"/>
         </aff>
     </xsl:template>
 

--- a/test/all/kitchen-sink.xml
+++ b/test/all/kitchen-sink.xml
@@ -50,7 +50,7 @@
 <contrib contrib-type="author" corresp="yes"><name><surname>Klatzmann</surname><given-names>David</given-names></name><xref ref-type="aff" rid="aff1">1</xref><xref ref-type="corresp" rid="cor1">&#x002A;</xref></contrib>
 <contrib contrib-type="author"><name><surname>the Brain Interfacing Laboratory</surname></name><xref ref-type="aff" rid="aff1">1</xref></contrib>
 <contrib contrib-type="author"><name><surname>the other Brain Interfacing Laboratory</surname></name></contrib>
-<aff id="aff1"><label>1</label><institution>Center for research in agricultural genomics, CRAG (CSIC-IRTA-UAB-UB)</institution>campus UAB, Cerdanyola del Vall&#x00E8;s08193BarcelonaCataloniaSpain</aff>
+<aff id="aff1"><label>1</label><institution>Center for research in agricultural genomics, CRAG (CSIC-IRTA-UAB-UB)</institution>, campus UAB, Cerdanyola del Vall&#x00E8;s, 08193 Barcelona, Catalonia, Spain</aff>
 </contrib-group>
 <author-notes>
 <fn id="n1" fn-type="present-address"><label>8</label><p>Present Institution: Parean biotechnologies, Saint-Malo, France</p></fn>

--- a/test/handle-singular-aff-no-links/kitchen-sink.xml
+++ b/test/handle-singular-aff-no-links/kitchen-sink.xml
@@ -50,7 +50,7 @@
 <contrib contrib-type="author" corresp="yes"><name><surname>Klatzmann</surname><given-names>David</given-names></name><xref ref-type="aff" rid="aff1">1</xref><xref ref-type="corresp" rid="cor1">&#x002A;</xref></contrib>
 <contrib contrib-type="author"><collab>the Brain Interfacing Laboratory</collab><xref ref-type="aff" rid="aff1">1</xref></contrib>
 <on-behalf-of>the other Brain Interfacing Laboratory</on-behalf-of>
-<aff id="aff1"><label>1</label><institution>Center for research in agricultural genomics, CRAG (CSIC-IRTA-UAB-UB)</institution><addr-line>campus UAB, Cerdanyola del Vall&#x00E8;s</addr-line><postal-code>08193</postal-code><city>Barcelona</city><state>Catalonia</state><country>Spain</country></aff>
+<aff id="aff1"><label>1</label><institution>Center for research in agricultural genomics, CRAG (CSIC-IRTA-UAB-UB)</institution>, <addr-line>campus UAB, Cerdanyola del Vall&#x00E8;s</addr-line>, <postal-code>08193</postal-code> <city>Barcelona</city>, <state>Catalonia</state>, <country>Spain</country></aff>
 </contrib-group>
 <author-notes>
 <fn id="n1" fn-type="present-address"><label>8</label><p>Present Institution: Parean biotechnologies, Saint-Malo, France</p></fn>


### PR DESCRIPTION
Use `node()` so that text is included as well