### PR TITLE
feat: Add passthrough mode to API

### DIFF
--- a/.github/workflows/verify-api.yaml
+++ b/.github/workflows/verify-api.yaml
@@ -27,10 +27,28 @@ jobs:
           docker run -d -p 3000:80 epp-biorxiv-xslt:api
           sleep 5 # wait for the container to start up
 
+      - name: Check api (passthrough)
+        run: |
+          output=$(curl --location 'http://localhost:3000' -H 'X-Passthrough: true' --data '<root><child>content</child></root>')
+          expected_output='{"xml":"<root><child>content</child></root>","logs":["Passthrough mode!"]}';
+          if [ "$output" != "$expected_output" ]; then
+            exit 1
+          fi
+          echo "$output" | jq
+
       - name: Check api
         run: |
-          curl --location 'http://localhost:3000' --data '<root><child>content</child></root>'
-          docker stop $(docker ps -q) # stop running containers
+          output=$(curl --location 'http://localhost:3000' --data '<root><child>content</child></root>')
+          expected_output='{"xml":"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\n<root><child>content</child></root>\n",';
+          if echo "$output" | grep -q "Passthrough mode"; then
+            exit 1
+          fi
+          echo "$output" | jq
+
+      - name: Stop running containers
+        run: |
+          docker stop $(docker ps -q)
+
   build-and-push:
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/master'

--- a/README.md
+++ b/README.md
@@ -472,3 +472,10 @@ docker run -p 8080:80 epp-biorxiv-xslt:api
 curl --location 'http://localhost:8080' \
 --data '<root><child>content</child></root>'
 ```
+
+## Test api (with passthrough)
+```
+curl --location 'http://localhost:8080' \
+-H 'X-Passthrough: true' \
+--data '<root><child>content</child></root>'
+```

--- a/app/app.test.ts
+++ b/app/app.test.ts
@@ -8,6 +8,8 @@ describe('POST /', () => {
     const res = await request(app).post('/').send(xml);
 
     expect(res.statusCode).toEqual(200);
-    expect(res.body).toStrictEqual({xml: '<root><child>content</child></root>'});
+    expect(res.body).toMatchObject({
+      xml: '<root><child>content</child></root>'
+    });
   });
 });

--- a/app/app.ts
+++ b/app/app.ts
@@ -11,7 +11,11 @@ app.post('/', async (req, res) => {
     if (typeof xmlData !== 'string') {
       throw new Error('request body should be a string');
     }
-    const response = await transform(xmlData);
+
+    // Check if the X-Passthrough header is set.
+    const passthroughMode = !!req.headers['x-passthrough'];
+
+    const response = await transform(xmlData, passthroughMode);
     res.json(response);
   } catch (error) {
     res.status(500).json({ error });

--- a/app/transform.test.ts
+++ b/app/transform.test.ts
@@ -4,6 +4,6 @@ describe('transform', () => {
   it('should transform the XML string', async () => {
     const xml = '<message>Hello world!</message>';
     const transformedXml = transform(xml);
-    expect(await transformedXml).toStrictEqual({xml: '<message>Hello world!</message>'});
+    expect(await transformedXml).toMatchObject({xml: '<message>Hello world!</message>'});
   });
 });

--- a/app/transform.ts
+++ b/app/transform.ts
@@ -10,11 +10,17 @@ import {
 import { tmpdir } from 'os';
 import { join } from 'path';
 
-const transform = async (xml: string, transformScript: string = '/app/scripts/transform.sh') : Promise<{xml: string, logs?: string[]}> => {
+const transform = async (xml: string, passthrough: boolean = false) : Promise<{xml: string, logs?: string[]}> => {
   return new Promise((resolve, reject) => {
-    if (!existsSync(transformScript)) {
+    const transformScript = '/app/scripts/transform.sh';
+    if (passthrough || !existsSync(transformScript)) {
       // If access to transformScript is not available then return xml unchanged.
-      resolve({xml});
+      resolve({
+        xml,
+        logs: [
+          'Passthrough mode!',
+        ],
+      });
       return;
     }
 


### PR DESCRIPTION
Added a passthrough mode to API where the request body is returned unchanged if the 'X-Passthrough' header is set. Updated the README.md with example of using the new feature. Also, updated the verify-api.yaml to include a check for the passthrough mode.