### PR TITLE
Replace deprecated openjdk:11 Docker base image with eclipse-temurin:11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ARG node_version=18.16-slim
 
 # Base stage for building Java app
-FROM openjdk:11 as base
+FROM eclipse-temurin:11-jre as base
 
 RUN apt-get update && apt-get install -y wget libxml2-utils
 


### PR DESCRIPTION
`openjdk:11` has been removed from Docker Hub. `eclipse-temurin:11` is the officially recommended successor maintained by Eclipse Adoptium.